### PR TITLE
fix: remove unnecessary f-string prefix from NER_SYSTEM_PROMPT

### DIFF
--- a/encite/ner.py
+++ b/encite/ner.py
@@ -10,7 +10,7 @@ ENTITY_NAME_RE = re.compile(r"<name>(.*?)</name>", re.DOTALL)
 SEPARATORS = {" ", ".", ",", "\n", "\t"}
 
 
-NER_SYSTEM_PROMPT = f"""You are a named entity recognition (NER) expert.
+NER_SYSTEM_PROMPT = """You are a named entity recognition (NER) expert.
 Extract all named entities from the provided document.
 
 INSTRUCTIONS:


### PR DESCRIPTION
## Summary
• Fix linting error by removing unnecessary f-string prefix from NER_SYSTEM_PROMPT constant

## Test plan
- [x] Verify linting passes with `uv run ruff check`
- [x] Confirm no functional changes to NER behavior

🤖 Generated with [Claude Code](https://claude.ai/code)